### PR TITLE
use semver notation

### DIFF
--- a/src/strftimerl.app.src
+++ b/src/strftimerl.app.src
@@ -1,7 +1,7 @@
 {application, strftimerl,
  [
   {description, ""},
-  {vsn, "1"},
+  {vsn, "0.1.0"},
   {registered, []},
   {applications, [
                   kernel,


### PR DESCRIPTION
What do you think about using semver notation? It would be easy to push this lib to hex.pm for example.
I need this changes because I use this library in Erlang application which part of elixir umbrella application and mix cannot work with dependencies which use another version notation.
```Unchecked dependencies for environment test:
* strftimerl (https://github.com/kennystone/strftimerl.git)
  the app file specified a non-Semantic Versioning format: "1". Mix can only match the requirement ">= 0.0.0" against semantic versions. Please fix the application version or use a regex as a requirement to match against any version```